### PR TITLE
Added support for specifying address type - e.g. IPv4/IPv6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ postfix_relayhost_pass: false
 
 # The interfaces for Postfix to listen on
 postfix_inet_interfaces: 'loopback-only'
+
+# The protocols Postfix will use when it makes or accepts network connections, and also controls what DNS lookups Postfix will use when it makes network connections.
+postfix_inet_protocols: 'all'
+
+# The address type ("ipv6", "ipv4" or "any") that the Postfix SMTP client will try first, when a destination has IPv6 and IPv4 addresses with equal MX preference.
+postfix_smtp_address_preference: 'all'
 ```
 
 ## Examples

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # The variables file used for Postfix playbooks.
 # If not overriden in inventory or as a parameter, this is the value that will be used
 
+postfix_origin: '{{ ansible_hostname }}'
 postfix_domain: ''
 postfix_notify_email: false
 postfix_relayhost: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,5 @@ postfix_use_smtp: false
 postfix_relayhost_user: false
 postfix_relayhost_pass: false
 postfix_inet_interfaces: 'loopback-only'
+postfix_inet_protocols: 'all'
+postfix_smtp_address_preference: 'all'

--- a/templates/main-cf.j2
+++ b/templates/main-cf.j2
@@ -32,6 +32,7 @@ smtp_use_tls = yes
 
 {% endif %}
 # General
+myorigin = {{ postfix_origin }}
 myhostname = {{ ansible_hostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
@@ -41,3 +42,5 @@ mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = {{postfix_inet_interfaces}}
+inet_protocols = {{postfix_inet_protocols}}
+smtp_address_preference = {{postfix_smtp_address_preference}}


### PR DESCRIPTION
I needed this when setting up a Signiant Manager which requires IPv4 to be switched off
